### PR TITLE
Add dependency to `which`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/hail2u/grunt-png2ico.git"
+  },
+  "dependencies": {
+    "which": "1.2.1"
   }
 }


### PR DESCRIPTION
Without it, the grunt task will fail with the following error:

```
Running "png2ico:win" (png2ico) task
Warning: Cannot find module 'which' Use --force to continue.
```
